### PR TITLE
play nicer with bundles that use mvp args

### DIFF
--- a/lib/Dist/Zilla/Role/PluginBundle/PluginRemover.pm
+++ b/lib/Dist/Zilla/Role/PluginBundle/PluginRemover.pm
@@ -21,7 +21,12 @@ Defaults to C<-remove>.
 
 sub plugin_remover_attribute { '-remove' };
 
-sub mvp_multivalue_args { $_[0]->plugin_remover_attribute };
+sub mvp_multivalue_args { }
+around mvp_multivalue_args => sub {
+  my $orig = shift;
+  my $self = shift;
+  $self->plugin_remover_attribute, $self->$orig(@_)
+};
 
 =method remove_plugins
 


### PR DESCRIPTION
The documentation says:

```
NOTE: If you overwrite mvp_multivalue_args you'll need to include the
value of plugin_remover_attribute (-remove by default) if you want to
retain this functionality. As always, patches and suggestions are welcome.
```

We can avoid having to do this in the composing class by using a method
modifier, with a fallback method (to wrap in case the class doesn't define
one) that returns nothing.
