### PR TITLE
Also match against custom plugin name, so as to not remove all plugins of a given type

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for Dist-Zilla-Role-PluginBundle-PluginRemover
 
 {{$NEXT}}
 
+  - also allow removing individual plugins by unique name, where more than one
+    plugin of the same type is in use
+
 0.102     2013-04-15T05:08:23Z
 
   - Use 'around' (and an empty sub) to add attribute name to

--- a/lib/Dist/Zilla/Role/PluginBundle/PluginRemover.pm
+++ b/lib/Dist/Zilla/Role/PluginBundle/PluginRemover.pm
@@ -47,15 +47,32 @@ but is defined separately in case you would like
 to use the functionality without the voodoo that occurs
 when consuming this role.
 
+The plugin name to match against all plugins can be given as either the plugin
+moniker (like you might provide in your config file, expanded via
+L<Dist::Zilla::Util/expand_config>), or the unique plugin name used to
+differentiate multiple plugins of the same type. For example, in this
+configuration:
+
+    [Foo::Bar / plugin 1]
+    [Foo::Bar / plugin 2]
+
+passing C<'Foo::Bar'> to C<remove_plugins> will remove both these plugins from
+the configuration, but only the first is removed when passing C<'plugin 1'>.
+
 =cut
 
 sub remove_plugins {
   my ($self, $remove, @plugins) = @_;
 
-  # stolen 100% from @Filter (thanks rjbs!)
+  # plugin specifications look like:
+  # [ plugin_name, plugin_class, arguments ]
+
+  # stolen 99% from @Filter (thanks rjbs!)
   require List::MoreUtils;
   for my $i (reverse 0 .. $#plugins) {
     splice @plugins, $i, 1 if List::MoreUtils::any(sub {
+      $plugins[$i][0] eq $_
+        or
       $plugins[$i][1] eq Dist::Zilla::Util->expand_config_package_name($_)
     }, @$remove);
   }

--- a/t/remove.t
+++ b/t/remove.t
@@ -11,8 +11,10 @@ use Dist::Zilla::Util;
 sub e { Dist::Zilla::Util->expand_config_package_name($_[0]); }
 
 my @plugins = (
-  [Foo => e('Foo')],
-  [Bar => e('Bar')],
+  ['@Bundle/Foo' => e('Foo')],  # default name
+  ['second Foo' => e('Foo')],   # custom name
+  ['@Bundle/Bar' => e('Bar')],
+  ['second Bar' => e('Bar')],
 );
 
   is_deeply
@@ -22,17 +24,33 @@ my @plugins = (
 
   is_deeply
     [ $mod->remove_plugins([qw(Foo)], @plugins) ],
-    [ [Bar => e('Bar')] ],
-    'one removed';
+    [
+      ['@Bundle/Bar' => e('Bar')],
+      ['second Bar' => e('Bar')],
+    ],
+    'all Foo removed';
 
   is_deeply
     [ $mod->remove_plugins([qw(Bar)], @plugins) ],
-    [ [Foo => e('Foo')] ],
-    'other removed';
+    [
+      ['@Bundle/Foo' => e('Foo')],
+      ['second Foo' => e('Foo')],
+    ],
+    'all Bar removed';
 
   is_deeply
     [ $mod->remove_plugins([qw(Bar Foo)], @plugins) ],
     [ ],
     'nothing left';
+
+  is_deeply
+    [ $mod->remove_plugins(['second Foo'], @plugins) ],
+    [
+      ['@Bundle/Foo' => e('Foo')],
+      ['@Bundle/Bar' => e('Bar')],
+      ['second Bar' => e('Bar')],
+    ],
+    'one Foo removed';
+
 
 done_testing;


### PR DESCRIPTION
Say I have this bundle config:

    $self->add_plugins(
        ...
        [ 'Git::Commit' => 'release commit' => { ... } ],
        ...

        [ 'NextRelease' => { ... } ],       # bump {{$NEXT}} in Changes
        [ 'Git:Commit' => 'post-release commot' => { ... } ],
        ...
    );

..there is no way presently to remove just one of the Git::Commit plugins,
without the other.  We can target a specific plugin by also looking for its
unique plugin name when we iterate over the list of plugins.
